### PR TITLE
Only check if time is greater than expiration if expiration isn't zero

### DIFF
--- a/app/models/Users.php
+++ b/app/models/Users.php
@@ -172,7 +172,11 @@ class Users extends \Phalcon\Mvc\Model
 
 
     public function isClubMember() {
-        return time() > $this->club_expiration;
+		if ($this->club_expiration > 0) {
+			return time() > $this->club_expiration;
+		}
+		
+		return false;
     }
 
 


### PR DESCRIPTION
This is because if a user has not bought HC or their HC has expired, it will be 0 so time() would always be greater than, therefore the server would always think the user had HC either way.

This commit fixes that.